### PR TITLE
Fix the expected 'auto-selection' behaviour that should occur when a new address list element component is created

### DIFF
--- a/src/app/address-list/address-list-element/address-list-element.component.ts
+++ b/src/app/address-list/address-list-element/address-list-element.component.ts
@@ -14,12 +14,12 @@ export class AddressListElementComponent implements OnInit, OnDestroy {
   subscription: Subscription;
 
   constructor(private notificationService: NotificationService) {
-    this.subscription = notificationService.selectedElement.subscribe(newAddress => {
-      this.selected = newAddress === this.address ? true : false;
-    });
   }
 
   ngOnInit(): void {
+    this.subscription = this.notificationService.selectedElement.subscribe(newAddress => {
+      this.selected = newAddress === this.address ? true : false;
+    });
   }
 
   getFullName(): string {


### PR DESCRIPTION
## Description

Previously, when a new 'address-list-element` component was created, it would not be properly given the "selected" state. This is because the `selected` state of a `address-list-element` was previously "initialized" in the constructor while making use of an Input binding (`address`) to determine its value. However, since the values of Input bindings aren't processed until `ngOnInit()` is called, the value of `this.address`  in the constructor will always be `undefined` — resulting in the current unexpected behaviour.

## Previous Behaviour
<a href="https://gyazo.com/b6093c94dc991c2ceae52b44b469612d"><img src="https://i.gyazo.com/b6093c94dc991c2ceae52b44b469612d.gif" alt="Image from Gyazo" width="1000"/></a>

## New Behaviour
<a href="https://gyazo.com/86907d9f27480dc0962fc40dab56da3d"><img src="https://i.gyazo.com/86907d9f27480dc0962fc40dab56da3d.gif" alt="Image from Gyazo" width="1000"/></a>